### PR TITLE
Add a README for proposals

### DIFF
--- a/proposals/README.md
+++ b/proposals/README.md
@@ -1,0 +1,24 @@
+# REP – Readium Evolution Proposals
+
+Many changes, such as bug fixes, internal refactorings and documentation improvements, can be implemented and reviewed via the usual GitHub tools: issues and pull requests.
+
+However, we ask that any change impacting the public API be put through a bit of design process and produce a consensus among the Readium community.
+
+The REP (Readium Evolution Proposals) process is intended to provide a public space for discussing new features entering the Readium toolkit, so that all stakeholders can be confident about the direction the toolkit is following. It also serves as an archive and reference for existing (or soon to be) features.
+
+## Approved Proposals
+
+### [001 – Format API](001-format-api.md)
+
+This proposal introduces a dedicated API to easily figure out a file format.
+
+While a `Publication` is independent of any particular format, knowing the format of a publication file is necessary to:
+
+* determine the publication parser to use,
+* group or search publications by file type in the user's bookshelf.
+
+This API is not tied to `Publication`, so it can be used as a general purpose tool to guess a file format, e.g. during HTTP requests or in the LCP library.
+
+### [002 – Composite Fetcher API](002-composite-fetcher-api.md)
+
+The goal of this proposal is to make the fetcher more flexible using a [composite design pattern](https://en.wikipedia.org/wiki/Composite_pattern). We will introduce several `Fetcher` implementations to answer different needs, such as resource transformation and caching.


### PR DESCRIPTION
This adds a README in `proposals/`, with a brief explanation about the purpose of these proposals, and an overview of all approved proposals.

[Here's the formatted version](https://github.com/mickael-menu/architecture/blob/proposal/readme/proposals/README.md)