### PR TITLE
Add locator use cases

### DIFF
--- a/models/locators/use-cases/use-cases.md
+++ b/models/locators/use-cases/use-cases.md
@@ -1,0 +1,28 @@
+# Use-cases for Locators
+
+## Last reading position
+
+A user wants to see an EPUB open at where he left the publication the last time he was reading it. 
+
+The user may read on a different device, with a different screen size, but on the reflowable ebook, the content which was appearing at the top of the screen the last time he closed the ebook is again approximatively at the top of the screen. On a pre-paginated ebook, the page on which the publication is open is simply the page which was displayed when the ebook was closed. If the reading system is presenting a spread, the target screen is placed on the left-hand page. 
+
+## Bookmarks
+
+A user wants to place bookmarks on different locations of an ebook. Later on, when he selectes the bookmark, he wants his reading system to move to the position the bookmark was placed. 
+
+Again, the user may read on a different device, with a different screen size, but on the reflowable ebook, the content which was appearing at the top of the screen when the bookmark was created is again approximatively at the top of the screen. On a pre-paginated ebook, the page on which the publication is open is simply the page which was displayed when the bookmark was created. If the reading system is presenting a spread, the bookmark is placed on the left-hand page. 
+
+## Highlights
+
+A user wants to select and highlight a text fragment (word, sentence, paragraph, mathematical formula, etc.) in an ebook. The start and end characters of the highlighted fragment are not constrained by the html structure.
+
+## Annotations
+
+A user wants to select and highlight a text fragment in an ebook and attach a textual note to it.
+
+## Resilient locators
+
+A user wants to share his bookmarks, highlights and annotations with a friend who has a different edition of the ebook (with some textual modifications between the two editions). The friend wants to find these marks at the expected place in his ebook, as if they had the same edition.
+
+
+


### PR DESCRIPTION
I added a set of simple use cases to the Locator section. 

The goal is to trigger a review of our work on locators, update the model if needed and share it with the W3C EPUB 3 WG, which has a task force dedicated to "Virtual Locators" and aims at standardizing them (including the algorithm which calculates positions). 